### PR TITLE
Fix state-label rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,6 @@ function get_xyz(d) {
 
 function country_clicked(d) {
     
-                console.log(g);
     g.selectAll(["#states", "#cities"]).remove();
     state = null;
 

--- a/index.html
+++ b/index.html
@@ -175,6 +175,8 @@ function get_xyz(d) {
 }
 
 function country_clicked(d) {
+    
+                console.log(g);
     g.selectAll(["#states", "#cities"]).remove();
     state = null;
 
@@ -207,7 +209,9 @@ function country_clicked(d) {
                 d3.selectAll(".country-label").style('visibility', 'hidden');
                 d3.selectAll(".state-label").style('visibility', 'visible');
 
-                g.select("text")
+                
+                g.append("g")
+                        .attr("class", "state-labels")
                         .selectAll("text:not(.country-label)")
                         .data(topojson.feature(us, us.objects.states).features)
                         .enter()
@@ -224,7 +228,7 @@ function country_clicked(d) {
                             return  path.centroid(d)[1];
                         })
                         .attr("text-anchor", "middle")
-                        .attr('font-size', '1pt');
+                        .attr('font-size', '2pt');
                 //http://stackoverflow.com/questions/17425268/d3js-automatic-labels-placement-to-avoid-overlaps-force-repulsion
                 arrangeLabels();
 


### PR DESCRIPTION
The issue was that the state labels were getting attached to g.select('text') which targeted the first text node - the Afghanistan country-label. Thats why all the labels got hidden along with the country names.

Now it creates a new group node and attaches the labels under it.
